### PR TITLE
Support Brightness setting via PixelPusher commands

### DIFF
--- a/pixel-push.cc
+++ b/pixel-push.cc
@@ -65,12 +65,37 @@ public:
     }
   }
 
+  /**
+   * Manage direct commands, have to start w/ a magic 16 byte
+   * sequence (see server code)
+   */
+  virtual void HandlePusherCommand(const char *buf, size_t size) {
+    printf("Handle Pusher Commmand\n");
+  	uint8_t cmd = buf[0];
+
+    switch (cmd) {
+      case 0x01: // Brightness
+        if (size > 1) {
+          uint8_t br = buf[1];
+          if (br <= 100) {
+            matrix_->SetBrightness(br);
+          } else {
+            printf("Error, brightness too high: %i", br);
+          } 
+        }
+      break;
+      default:
+        printf("Unknown command\n");
+    }  
+  }
+
 private:
   RGBMatrix *const matrix_;
   FrameCanvas *off_screen_;
   FrameCanvas *on_screen_;
   bool full_update_requested_;
   Canvas *draw_canvas_;
+
 };
 
 static int usage(const char *progname) {


### PR DESCRIPTION
Format is 2 bytes:

- Byte 1: 0x01 (Brightness command)
- Byte 2: 0 to 100 (Brightness level)

Has to be preceded by the standard packet sequence number (4 bytes) and the "magic" command sequence of 16 bytes (look in server code)